### PR TITLE
[#21] 카카오로그인 리다이렉션 이슈

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
### 이슈
- 배포 환경에서 카카오로그인 리다이렉션이 `/#` 으로 되는 현상

### 변경사항
- Vercel 배포 환경에서 모든 요청을 루트 경로(`/`)로 리다이렉트하도록 `vercel.json` 파일에 리라이트 규칙을 추가했습니다.
- 이를 통해 클라이언트 사이드에서 모든 URL 경로를 처리할 수 있도록 하여, 서버 측에서의 엔드포인트 처리 문제를 해결했습니다.